### PR TITLE
Added missing signatures to avoid implicit function warnings during c…

### DIFF
--- a/include/ets_sys.h
+++ b/include/ets_sys.h
@@ -65,6 +65,8 @@ typedef void (* ets_isr_t)(void *);
 void ets_intr_lock(void);
 void ets_intr_unlock(void);
 void ets_isr_attach(int i, ets_isr_t func, void *arg);
+void ets_isr_mask(int);
+void ets_isr_unmask(int);
 
 void NmiTimSetFunc(void (*func)(void));
 


### PR DESCRIPTION
…ompile.